### PR TITLE
Fixing missing dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,13 @@ from glob import glob
 import os
 from os.path import join as pjoin
 from setuptools import setup, find_packages
+from setuptools.command.build_py import build_py
+
+
+class NPMInstall(build_py):
+    def run(self):
+        self.run_command('npm install --prefix test/functional yarn')
+        build_py.run(self)
 
 
 from jupyter_packaging import (
@@ -62,6 +69,7 @@ npm_install = combine_commands(
     ensure_targets(jstargets),
 )
 cmdclass['jsdeps'] = skip_if_exists(jstargets, npm_install)
+cmdclass['npm_install'] =  NPMInstall
 
 
 setup_args = dict(
@@ -93,6 +101,7 @@ setup_args = dict(
     python_requires=">=3.6",
     install_requires = [
         'ipywidgets>=7.0.0',
+        'jupyter_packaging'
     ],
     extras_require = {
         'test': [


### PR DESCRIPTION
Got two errors on the install (when following the readme). First, on the pip install command, I got
```
/var/folders/3k/220tdhsn33709gq9ylr8c6kh0000gp/T/buildprod664537749299.sh: line 2: yarn: command not found
```
This can be fixed by the user by running `npm install yarn` but that may not be evident to all users as the problematic line is buried in a lot of output. I edited the setup.py based on the solution described in https://stackoverflow.com/a/44698609/1825043 

Second, on
```
ipyniivue_ts % jupyter labextension develop . --overwrite
```

I got 
```
Traceback (most recent call last):
  File "/Users/christian/Library/CloudStorage/GoogleDrive-christian.oreilly@gmail.com/My Drive/Code/ipyniivue_ts/setup.py", line 14, in <module>
    from jupyter_packaging import (
ModuleNotFoundError: No module named 'jupyter_packaging'
An error occurred.
FileNotFoundError: The Python package `.` is not a valid package, it is missing the `setup.py` file.
See the log file for details:  /var/folders/3k/220tdhsn33709gq9ylr8c6kh0000gp/T/jupyterlab-debug-duugwarr.log
```

I added `jupyter_packaging` in the required packages.